### PR TITLE
Adaptable tile size

### DIFF
--- a/mapscaleview/src/main/java/com/github/pengrad/mapscaleview/MapScaleModel.java
+++ b/mapscaleview/src/main/java/com/github/pengrad/mapscaleview/MapScaleModel.java
@@ -2,8 +2,8 @@ package com.github.pengrad.mapscaleview;
 
 class MapScaleModel {
 
-    private static final double TILE_SIZE_METERS_AT_0_ZOOM = 156543.03;
-    private static final double TILE_SIZE_FT_AT_0_ZOOM = 513592.62;
+    private static final double EQUATOR_LENGTH_METERS = 40075016.686;
+    private static final double EQUATOR_LENGTH_FEET = 131479713.537;
 
     private static final int FT_IN_MILE = 5280;
 
@@ -20,6 +20,9 @@ class MapScaleModel {
     private float lastZoom = -1;
     private double lastLatitude = -100;
 
+    private double tileSizeMetersAt0Zoom = EQUATOR_LENGTH_METERS / 256;
+    private double tileSizeFeetAt0Zoom = EQUATOR_LENGTH_FEET / 256;
+
     MapScaleModel(float density) {
         this.density = density;
     }
@@ -30,6 +33,11 @@ class MapScaleModel {
             maxWidth = width;
             return true;
         } else return false;
+    }
+
+    void setTileSize(int tileSize) {
+        tileSizeMetersAt0Zoom = EQUATOR_LENGTH_METERS / tileSize;
+        tileSizeFeetAt0Zoom = EQUATOR_LENGTH_FEET / tileSize;
     }
 
     void setPosition(float zoom, double latitude) {
@@ -45,7 +53,7 @@ class MapScaleModel {
         double latitude = lastLatitude;
         if (zoom < 0 || Math.abs(latitude) > 90) return null;
 
-        double tileSizeAtZoom0 = meters ? TILE_SIZE_METERS_AT_0_ZOOM : TILE_SIZE_FT_AT_0_ZOOM;
+        double tileSizeAtZoom0 = meters ? tileSizeMetersAt0Zoom : tileSizeFeetAt0Zoom;
         float[] distances = meters ? METERS : FT;
 
         final double resolution = tileSizeAtZoom0 / density * Math.cos(latitude * Math.PI / 180) / Math.pow(2, zoom);

--- a/mapscaleview/src/main/java/com/github/pengrad/mapscaleview/MapScaleView.java
+++ b/mapscaleview/src/main/java/com/github/pengrad/mapscaleview/MapScaleView.java
@@ -45,6 +45,11 @@ public class MapScaleView extends View {
         }
     }
 
+    public void setTileSize(int tileSize) {
+        mapScaleModel.setTileSize(tileSize);
+        updateScales();
+    }
+
     public void setColor(@ColorInt int color) {
         drawer.setColor(color);
         invalidate();

--- a/sample/src/main/java/com/github/pengrad/mapscaleview/sample/MainActivity.kt
+++ b/sample/src/main/java/com/github/pengrad/mapscaleview/sample/MainActivity.kt
@@ -111,4 +111,10 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, OnCameraMoveListen
         direction = !direction
         scales.forEach { it.setExpandRtlEnabled(direction) }
     }
+
+    var largeTiles: Boolean = false
+    fun changeTileSize(view: View) {
+        largeTiles = !largeTiles
+        scales.forEach { it.setTileSize(if (largeTiles) 512 else 256) }
+    }
 }

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -72,6 +72,13 @@
             android:layout_height="wrap_content"
             android:onClick="changeFont"
             android:text="font" />
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="changeTileSize"
+            android:text="tile size"/>
+
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
Adds support to change the map tile size.

The `TILE_SIZE_METERS_AT_0_ZOOM` constant was hardcoded with a tile size of 256x256px, which, while working fine with google maps, returned a wrong scaling with e.g. the mapbox render (#14), which uses 512x512px tiles.

So instead of hardcoding the `TILE_SIZE_METERS_AT_0_ZOOM`, it's now calculated according to https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#Resolution_and_Scale whenever the tile size gets changed.
